### PR TITLE
Open work of art in a transparent modal

### DIFF
--- a/app/works/[id]/index.tsx
+++ b/app/works/[id]/index.tsx
@@ -1,64 +1,64 @@
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  useWindowDimensions,
-} from "react-native";
-import { Stack, useLocalSearchParams } from "expo-router";
-import { Image } from "expo-image";
-import Icon from "@expo/vector-icons/FontAwesome";
-import { useWorkByIdQuery } from "@/data/hooks/useWorkByIdQuery";
-import { useFavStatusQuery } from "@/data/hooks/useFavStatusQuery";
-import { useFavStatusMutation } from "@/data/hooks/useFavStatusMutation";
-import colors from "@/constants/colors";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { LoadingShade } from "@/components/LoadingShade";
+import { View, Text, ScrollView, Pressable, useWindowDimensions } from 'react-native'
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
+import { Image } from 'expo-image'
+import Icon from '@expo/vector-icons/FontAwesome'
+import { useWorkByIdQuery } from '@/data/hooks/useWorkByIdQuery'
+import { useFavStatusQuery } from '@/data/hooks/useFavStatusQuery'
+import { useFavStatusMutation } from '@/data/hooks/useFavStatusMutation'
+import colors from '@/constants/colors'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { LoadingShade } from '@/components/LoadingShade'
 
 export default function WorkScreen() {
-  const dimensions = useWindowDimensions();
+  const dimensions = useWindowDimensions()
 
-  const insets = useSafeAreaInsets();
+  const insets = useSafeAreaInsets()
 
   const { id } = useLocalSearchParams<{
-    id: string;
-  }>();
+    id: string
+  }>()
 
   // query art API for the work
-  const workQuery = useWorkByIdQuery(id);
-  const work = workQuery.data;
+  const workQuery = useWorkByIdQuery(id)
+  const work = workQuery.data
 
   // read fav status
-  const favQuery = useFavStatusQuery(id);
-  const isFav = favQuery.data;
+  const favQuery = useFavStatusQuery(id)
+  const isFav = favQuery.data
 
   // update fav status
-  const favMutation = useFavStatusMutation();
+  const favMutation = useFavStatusMutation()
+
+  const router = useRouter()
 
   return (
-    <View className="flex-1 bg-shade-1">
-      <Stack.Screen
-        options={{
-          title: work?.title || "Loading...",
-        }}
-      />
-      <ScrollView
-        contentContainerStyle={{ paddingBottom: insets.bottom }}
-        contentContainerClassName="bg-shade-1"
-      >
-        <View className="py-4 px-4 bg-shade-2">
-          <Image
-            style={{
-              height: dimensions.width > 640 ? 640 : dimensions.width,
-            }}
-            source={{ uri: work && work.images.web.url }}
-            contentFit="contain"
-            transition={500}
-          />
-        </View>
-        <View>
+    <View className="flex-1">
+      <View className="absolute bottom-0 top-0 left-0 right-0 opacity-50 bg-black" />
+      <View className="flex-1 bg-shade-1 bg-transparent my-20 mx-28 py-4">
+        <Stack.Screen
+          options={{
+            title: work?.title || 'Loading...',
+            presentation: 'transparentModal',
+            headerShown: false,
+          }}
+        />
+        <ScrollView
+          contentContainerStyle={{ paddingBottom: insets.bottom }}
+          contentContainerClassName="bg-shade-1"
+        >
           <View className="flex-row align-middle">
-            <Text className="flex-1 font-semibold text-3xl px-4 py-2 bg-shade-2">
+          <View className="justify-center px-4">
+          <Pressable
+                className="active:opacity-50"
+                disabled={favMutation.isPending}
+                onPress={() => {
+                  router.back()
+                }}
+              >
+                <Icon name="close" size={28} />
+              </Pressable>
+              </View>
+            <Text className="flex-1 font-semibold text-3xl px-4 py-2">
               {work?.title}
             </Text>
             <View className="justify-center px-4">
@@ -66,49 +66,55 @@ export default function WorkScreen() {
                 className="active:opacity-50"
                 disabled={favQuery.isLoading || favMutation.isPending}
                 onPress={() => {
-                  favMutation.mutate({ id, status: !isFav });
+                  favMutation.mutate({ id, status: !isFav })
                 }}
               >
-                <Icon
-                  name={isFav ? "star" : "star-o"}
-                  color={colors.tint}
-                  size={28}
-                />
+                <Icon name={isFav ? 'star' : 'star-o'} color={colors.tint} size={28} />
               </Pressable>
             </View>
           </View>
-          <View className="px-4 gap-y-2 py-2">
-            {work?.creators.length ? (
-              <Text className="text-l">{work.creators[0].description}</Text>
-            ) : null}
-            <Text className="text-l">{work?.date_text}</Text>
-            <Text className="text-l">{work?.technique}</Text>
+          <View className="py-4 px-4 bg-shade-2">
+            <Image
+              style={{
+                height: dimensions.width > 640 ? 640 : dimensions.width,
+              }}
+              source={{ uri: work && work.images.web.url }}
+              contentFit="contain"
+              transition={500}
+            />
           </View>
-          {work?.description && (
-            <>
-              <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">Description</Text>
-              <View className="px-4 gap-y-2 py-2">
-                <Text className="text-l">{stripTags(work.description)}</Text>
-              </View>
-            </>
-          )}
-          {work?.did_you_know && (
-            <>
-              <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">
-                Did you know?
-              </Text>
-              <View className="px-4 gap-y-2 py-2">
-                <Text className="text-l">{stripTags(work.did_you_know)}</Text>
-              </View>
-            </>
-          )}
-        </View>
-      </ScrollView>
-      <LoadingShade isLoading={workQuery.isLoading || favQuery.isLoading} />
+          <View>
+            <View className="px-4 gap-y-2 py-2">
+              {work?.creators.length ? (
+                <Text className="text-l">{work.creators[0].description}</Text>
+              ) : null}
+              <Text className="text-l">{work?.date_text}</Text>
+              <Text className="text-l">{work?.technique}</Text>
+            </View>
+            {work?.description && (
+              <>
+                <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">Description</Text>
+                <View className="px-4 gap-y-2 py-2">
+                  <Text className="text-l">{stripTags(work.description)}</Text>
+                </View>
+              </>
+            )}
+            {work?.did_you_know && (
+              <>
+                <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">Did you know?</Text>
+                <View className="px-4 gap-y-2 py-2">
+                  <Text className="text-l">{stripTags(work.did_you_know)}</Text>
+                </View>
+              </>
+            )}
+          </View>
+        </ScrollView>
+        <LoadingShade isLoading={workQuery.isLoading || favQuery.isLoading} />
+      </View>
     </View>
-  );
+  )
 }
 
 function stripTags(htmlish: string) {
-  return htmlish.replace(/<[^>]*>?/gm, "");
+  return htmlish.replace(/<[^>]*>?/gm, '')
 }

--- a/app/works/[id]/index.tsx
+++ b/app/works/[id]/index.tsx
@@ -1,6 +1,5 @@
 import { View, Text, ScrollView, Pressable, useWindowDimensions } from 'react-native'
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
-import { Stack, useLocalSearchParams } from 'expo-router'
 import { Image } from 'expo-image'
 import Icon from '@expo/vector-icons/FontAwesome'
 import { useWorkByIdQuery } from '@/data/hooks/useWorkByIdQuery'


### PR DESCRIPTION
This only looks right currently on a desktop-sized web page. Also note the transparency doesn't continue all the way through the page due to the stack navigator actually being inside an outer frame, due to bad layout decisions I made a long time ago

<img width="884" alt="image" src="https://github.com/user-attachments/assets/fb4a8d2b-ccb7-4dc5-b49c-64f6baac7335">

How to try it out:
1. Run `yarn start-local`
2. Browse to an art category
3. Open a work of art
