### PR TITLE
Transparent modal doesnt work with a layout file

### DIFF
--- a/app/works/[id]/_layout.tsx
+++ b/app/works/[id]/_layout.tsx
@@ -1,0 +1,7 @@
+import { Slot } from 'expo-router'
+
+export default () => {
+  return (
+    <Slot />
+  )
+}

--- a/app/works/[id]/index.tsx
+++ b/app/works/[id]/index.tsx
@@ -1,64 +1,64 @@
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  useWindowDimensions,
-} from "react-native";
-import { Stack, useLocalSearchParams } from "expo-router";
-import { Image } from "expo-image";
-import Icon from "@expo/vector-icons/FontAwesome";
-import { useWorkByIdQuery } from "@/data/hooks/useWorkByIdQuery";
-import { useFavStatusQuery } from "@/data/hooks/useFavStatusQuery";
-import { useFavStatusMutation } from "@/data/hooks/useFavStatusMutation";
-import colors from "@/constants/colors";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { LoadingShade } from "@/components/LoadingShade";
+import { View, Text, ScrollView, Pressable, useWindowDimensions } from 'react-native'
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
+import { Image } from 'expo-image'
+import Icon from '@expo/vector-icons/FontAwesome'
+import { useWorkByIdQuery } from '@/data/hooks/useWorkByIdQuery'
+import { useFavStatusQuery } from '@/data/hooks/useFavStatusQuery'
+import { useFavStatusMutation } from '@/data/hooks/useFavStatusMutation'
+import colors from '@/constants/colors'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { LoadingShade } from '@/components/LoadingShade'
 
 export default function WorkScreen() {
-  const dimensions = useWindowDimensions();
+  const dimensions = useWindowDimensions()
 
-  const insets = useSafeAreaInsets();
+  const insets = useSafeAreaInsets()
 
   const { id } = useLocalSearchParams<{
-    id: string;
-  }>();
+    id: string
+  }>()
 
   // query art API for the work
-  const workQuery = useWorkByIdQuery(id);
-  const work = workQuery.data;
+  const workQuery = useWorkByIdQuery(id)
+  const work = workQuery.data
 
   // read fav status
-  const favQuery = useFavStatusQuery(id);
-  const isFav = favQuery.data;
+  const favQuery = useFavStatusQuery(id)
+  const isFav = favQuery.data
 
   // update fav status
-  const favMutation = useFavStatusMutation();
+  const favMutation = useFavStatusMutation()
+
+  const router = useRouter()
 
   return (
-    <View className="flex-1 bg-shade-1">
-      <Stack.Screen
-        options={{
-          title: work?.title || "Loading...",
-        }}
-      />
-      <ScrollView
-        contentContainerStyle={{ paddingBottom: insets.bottom }}
-        contentContainerClassName="bg-shade-1"
-      >
-        <View className="py-4 px-4 bg-shade-2">
-          <Image
-            style={{
-              height: dimensions.width > 640 ? 640 : dimensions.width,
-            }}
-            source={{ uri: work && work.images.web.url }}
-            contentFit="contain"
-            transition={500}
-          />
-        </View>
-        <View>
+    <View className="flex-1">
+      <View className="absolute bottom-0 top-0 left-0 right-0 opacity-50 bg-black" />
+      <View className="flex-1 bg-shade-1 bg-transparent my-20 mx-28 py-4">
+        <Stack.Screen
+          options={{
+            title: work?.title || 'Loading...',
+            presentation: 'transparentModal',
+            headerShown: false,
+          }}
+        />
+        <ScrollView
+          contentContainerStyle={{ paddingBottom: insets.bottom }}
+          contentContainerClassName="bg-shade-1"
+        >
           <View className="flex-row align-middle">
-            <Text className="flex-1 font-semibold text-3xl px-4 py-2 bg-shade-2">
+          <View className="justify-center px-4">
+          <Pressable
+                className="active:opacity-50"
+                disabled={favMutation.isPending}
+                onPress={() => {
+                  router.back()
+                }}
+              >
+                <Icon name="close" size={28} />
+              </Pressable>
+              </View>
+            <Text className="flex-1 font-semibold text-3xl px-4 py-2">
               {work?.title}
             </Text>
             <View className="justify-center px-4">
@@ -66,49 +66,55 @@ export default function WorkScreen() {
                 className="active:opacity-50"
                 disabled={favQuery.isLoading || favMutation.isPending}
                 onPress={() => {
-                  favMutation.mutate({ id, status: !isFav });
+                  favMutation.mutate({ id, status: !isFav })
                 }}
               >
-                <Icon
-                  name={isFav ? "star" : "star-o"}
-                  color={colors.tint}
-                  size={28}
-                />
+                <Icon name={isFav ? 'star' : 'star-o'} color={colors.tint} size={28} />
               </Pressable>
             </View>
           </View>
-          <View className="px-4 gap-y-2 py-2">
-            {work?.creators.length ? (
-              <Text className="text-l">{work.creators[0].description}</Text>
-            ) : null}
-            <Text className="text-l">{work?.date_text}</Text>
-            <Text className="text-l">{work?.technique}</Text>
+          <View className="py-4 px-4 bg-shade-2">
+            <Image
+              style={{
+                height: dimensions.width > 640 ? 640 : dimensions.width,
+              }}
+              source={{ uri: work && work.images.web.url }}
+              contentFit="contain"
+              transition={500}
+            />
           </View>
-          {work?.description && (
-            <>
-              <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">Description</Text>
-              <View className="px-4 gap-y-2 py-2">
-                <Text className="text-l">{stripTags(work.description)}</Text>
-              </View>
-            </>
-          )}
-          {work?.did_you_know && (
-            <>
-              <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">
-                Did you know?
-              </Text>
-              <View className="px-4 gap-y-2 py-2">
-                <Text className="text-l">{stripTags(work.did_you_know)}</Text>
-              </View>
-            </>
-          )}
-        </View>
-      </ScrollView>
-      <LoadingShade isLoading={workQuery.isLoading || favQuery.isLoading} />
+          <View>
+            <View className="px-4 gap-y-2 py-2">
+              {work?.creators.length ? (
+                <Text className="text-l">{work.creators[0].description}</Text>
+              ) : null}
+              <Text className="text-l">{work?.date_text}</Text>
+              <Text className="text-l">{work?.technique}</Text>
+            </View>
+            {work?.description && (
+              <>
+                <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">Description</Text>
+                <View className="px-4 gap-y-2 py-2">
+                  <Text className="text-l">{stripTags(work.description)}</Text>
+                </View>
+              </>
+            )}
+            {work?.did_you_know && (
+              <>
+                <Text className="text-xl font-semibold px-4 py-2 bg-shade-2">Did you know?</Text>
+                <View className="px-4 gap-y-2 py-2">
+                  <Text className="text-l">{stripTags(work.did_you_know)}</Text>
+                </View>
+              </>
+            )}
+          </View>
+        </ScrollView>
+        <LoadingShade isLoading={workQuery.isLoading || favQuery.isLoading} />
+      </View>
     </View>
-  );
+  )
 }
 
 function stripTags(htmlish: string) {
-  return htmlish.replace(/<[^>]*>?/gm, "");
+  return htmlish.replace(/<[^>]*>?/gm, '')
 }

--- a/app/works/[id]/index.tsx
+++ b/app/works/[id]/index.tsx
@@ -1,6 +1,5 @@
 import { View, Text, ScrollView, Pressable, useWindowDimensions } from 'react-native'
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
-import { Stack, useLocalSearchParams } from 'expo-router'
 import { Image } from 'expo-image'
 import Icon from '@expo/vector-icons/FontAwesome'
 import { useWorkByIdQuery } from '@/data/hooks/useWorkByIdQuery'


### PR DESCRIPTION
This happens regardless of what I do, once I add a layout file to `works/[id]`, regardless of whether it's a `Stack` or `Slot` or whatever.

Seems to resemble this issue: https://github.com/react-navigation/react-navigation/issues/9879

<img width="820" alt="image" src="https://github.com/user-attachments/assets/90170210-7497-47fc-bd23-e2fc12f0d360">

How to try it out:

Run yarn start-local
Browse to an art category
Open a work of art
